### PR TITLE
Renamed Status to States for LinearTimerStatus enum

### DIFF
--- a/lineartimer/src/main/java/io/github/krtkush/lineartimer/LinearTimer.java
+++ b/lineartimer/src/main/java/io/github/krtkush/lineartimer/LinearTimer.java
@@ -1,7 +1,6 @@
 package io.github.krtkush.lineartimer;
 
 import android.animation.ObjectAnimator;
-import android.os.CountDownTimer;
 import android.view.animation.AccelerateDecelerateInterpolator;
 
 /**
@@ -72,7 +71,7 @@ public class LinearTimer implements ArcProgressAnimation.TimerListener {
             linearTimerView.setPreFillAngle(preFillAngle);
 
             //Store the current status code in intStatusCode integer
-            intStatusCode = LinearTimerStatus.INITIALIZED.getStaus();
+            intStatusCode = LinearTimerStates.INITIALIZED.getStaus();
 
             // If the user wants to show the progress in counter clock wise manner,
             // we flip the view on its Y-Axis and let it function as is.
@@ -103,10 +102,10 @@ public class LinearTimer implements ArcProgressAnimation.TimerListener {
     public void pauseTimer() throws IllegalStateException {
         if (basicParametersCheck()) {
             //timer may be paused only in active state
-            if (intStatusCode == LinearTimerStatus.ACTIVE.getStaus()) {
+            if (intStatusCode == LinearTimerStates.ACTIVE.getStaus()) {
 
                 //Store the current status code in intStatusCode integer
-                intStatusCode = LinearTimerStatus.PAUSED.getStaus();
+                intStatusCode = LinearTimerStates.PAUSED.getStaus();
 
                 //Clear animations off of linearTimerView, set prefillAngle to current state and refresh view
                 linearTimerView.clearAnimation();
@@ -125,10 +124,10 @@ public class LinearTimer implements ArcProgressAnimation.TimerListener {
 
     public void resumeTimer() throws IllegalStateException {
         if (basicParametersCheck()) {
-            if (intStatusCode == LinearTimerStatus.PAUSED.getStaus()) {
+            if (intStatusCode == LinearTimerStates.PAUSED.getStaus()) {
 
                 //Store the current status code in intStatusCode integer
-                intStatusCode = LinearTimerStatus.ACTIVE.getStaus();
+                intStatusCode = LinearTimerStates.ACTIVE.getStaus();
 
                 //Reinitialize the animations as it may not be simply continued.
                 //The animation is reinitialized with the linearTimerView, the ending angle and duration
@@ -166,9 +165,9 @@ public class LinearTimer implements ArcProgressAnimation.TimerListener {
     public void startTimer() {
 
         if (basicParametersCheck()) {
-            if (intStatusCode == LinearTimerStatus.INITIALIZED.getStaus()) {
+            if (intStatusCode == LinearTimerStates.INITIALIZED.getStaus()) {
                 //Store the current status code in intStatusCode integer
-                intStatusCode = LinearTimerStatus.ACTIVE.getStaus();
+                intStatusCode = LinearTimerStates.ACTIVE.getStaus();
                 arcProgressAnimation = new ArcProgressAnimation(linearTimerView, endingAngle, this);
                 arcProgressAnimation.setDuration(animationDuration);
                 linearTimerView.startAnimation(arcProgressAnimation);
@@ -186,7 +185,7 @@ public class LinearTimer implements ArcProgressAnimation.TimerListener {
         if (basicParametersCheck()) {
             if (arcProgressAnimation != null) {
                 //Store the current status code in intStatusCode integer
-                intStatusCode = LinearTimerStatus.ACTIVE.getStaus();
+                intStatusCode = LinearTimerStates.ACTIVE.getStaus();
 
                 //Reset the pre filling angle as passed by user during initialization
                 linearTimerView.setPreFillAngle(preFillAngle);
@@ -208,10 +207,10 @@ public class LinearTimer implements ArcProgressAnimation.TimerListener {
      */
     public void resetTimer() {
         if (basicParametersCheck()) {
-            if (intStatusCode == LinearTimerStatus.PAUSED.getStaus()
-                    || intStatusCode == LinearTimerStatus.FINISHED.getStaus()) {
+            if (intStatusCode == LinearTimerStates.PAUSED.getStaus()
+                    || intStatusCode == LinearTimerStates.FINISHED.getStaus()) {
                 //Store the current status code in intStatusCode integer
-                intStatusCode = LinearTimerStatus.INITIALIZED.getStaus();
+                intStatusCode = LinearTimerStates.INITIALIZED.getStaus();
 
                 //Cancel the circle animation
                 arcProgressAnimation.cancel();
@@ -240,22 +239,22 @@ public class LinearTimer implements ArcProgressAnimation.TimerListener {
      * 4) Finished
      * @return Returns an enum that defines the current state of the LinearTimer.
      */
-    public LinearTimerStatus getState() {
+    public LinearTimerStates getState() {
         switch (intStatusCode) {
             case 0:
-                return LinearTimerStatus.INITIALIZED;
+                return LinearTimerStates.INITIALIZED;
 
             case 1:
-                return LinearTimerStatus.ACTIVE;
+                return LinearTimerStates.ACTIVE;
 
             case 2:
-                return LinearTimerStatus.PAUSED;
+                return LinearTimerStates.PAUSED;
 
             case 3:
-                return LinearTimerStatus.FINISHED;
+                return LinearTimerStates.FINISHED;
 
             default:
-                return LinearTimerStatus.INITIALIZED;
+                return LinearTimerStates.INITIALIZED;
         }
     }
 
@@ -264,7 +263,7 @@ public class LinearTimer implements ArcProgressAnimation.TimerListener {
         try {
             if (listenerCheck()) {
                 //Store the current status code in intStatusCode integer
-                intStatusCode = LinearTimerStatus.FINISHED.getStaus();
+                intStatusCode = LinearTimerStates.FINISHED.getStaus();
                 timerListener.animationComplete();
             }
         } catch (LinearTimerListenerMissingException ex) {
@@ -380,7 +379,7 @@ public class LinearTimer implements ArcProgressAnimation.TimerListener {
 
             @Override
             public void onFinish() {
-                if(intStatusCode != LinearTimerStatus.PAUSED.getStaus())
+                if(intStatusCode != LinearTimerStates.PAUSED.getStaus())
                     timerListener.timerTick(0);
             }
         };

--- a/lineartimer/src/main/java/io/github/krtkush/lineartimer/LinearTimerCountDownTimer.java
+++ b/lineartimer/src/main/java/io/github/krtkush/lineartimer/LinearTimerCountDownTimer.java
@@ -33,7 +33,7 @@ public class LinearTimerCountDownTimer extends CountDownTimer {
 
     @Override
     public void onFinish() {
-        if (LinearTimer.intStatusCode != LinearTimerStatus.PAUSED.getStaus())
+        if (LinearTimer.intStatusCode != LinearTimerStates.PAUSED.getStaus())
             timerListener.timerTick(0);
     }
 

--- a/lineartimer/src/main/java/io/github/krtkush/lineartimer/LinearTimerCountUpTimer.java
+++ b/lineartimer/src/main/java/io/github/krtkush/lineartimer/LinearTimerCountUpTimer.java
@@ -26,7 +26,7 @@ public class LinearTimerCountUpTimer extends CountUpTimer {
 
     @Override
     public void onFinish() {
-        if (LinearTimer.intStatusCode != LinearTimerStatus.PAUSED.getStaus())
+        if (LinearTimer.intStatusCode != LinearTimerStates.PAUSED.getStaus())
             timerListener.timerTick(timerDuration);
     }
 

--- a/lineartimer/src/main/java/io/github/krtkush/lineartimer/LinearTimerStates.java
+++ b/lineartimer/src/main/java/io/github/krtkush/lineartimer/LinearTimerStates.java
@@ -4,7 +4,7 @@ package io.github.krtkush.lineartimer;
  * The enum status codes enum holds the various states of LinearTimer. It may be used to diversify
  * user flow depending on which state the timer is in.
  */
-public enum LinearTimerStatus {
+public enum LinearTimerStates {
 
     /**
      * The initialized state is when LinearTimer has not run even once and/or .reset() method was executed.
@@ -34,14 +34,14 @@ public enum LinearTimerStatus {
     FINISHED(3);
 
     /**
-     * An integer to hold the integer representation of each of the statuses defined in LinearTimerStatus enum.
+     * An integer to hold the integer representation of each of the statuses defined in LinearTimerStates enum.
      */
     private int intStatusCode;
 
-    //The constructor for LinearTimerStatus enum that accepts an integer type parameter from each of the
-    //statuses on the LinearTimerStatus enum and assigns it to intStatusCode integer which may be returned
+    //The constructor for LinearTimerStates enum that accepts an integer type parameter from each of the
+    //statuses on the LinearTimerStates enum and assigns it to intStatusCode integer which may be returned
     //by getStats() method
-    LinearTimerStatus(int intStatus) {
+    LinearTimerStates(int intStatus) {
         intStatusCode = intStatus;
     }
 


### PR DESCRIPTION
Renamed the enum `LinearTimerStatus` to `LinearTimerStates`. Seemed a better match to the purpose served.